### PR TITLE
Makefile: make latexpdf the default goal

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,23 +1,35 @@
-# Minimal makefile for Sphinx documentation
-#
 
-# You can set these variables from the command line, and also
-# from the environment for the first two.
+.DEFAULT_GOAL := all
+
 SPHINXOPTS    ?=
 SPHINXBUILD   ?= sphinx-build
 SOURCEDIR     = source
 BUILDDIR      = build
 
-# Put it first so that "make" without argument is like "make help".
-help:
-	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
 
-clean:
+# PHONY TARGETS #
+#################
+
+.PHONY : all help clean Makefile
+
+
+# Build all supported output formats.
+all : latexpdf
+
+
+clean :
 	@rm -Rf $(BUILDDIR)
 
-.PHONY: help clean Makefile
+
+help :
+	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+
+
+
+# REAL TARGETS #
+################
 
 # Catch-all target: route all unknown targets to Sphinx using the new
 # "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
-%: Makefile
+% : Makefile
 	$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)

--- a/dev/CONTRIBUTING.md
+++ b/dev/CONTRIBUTING.md
@@ -33,7 +33,7 @@ pip install -r requirements.txt
 3. Build the documentation using GNU `make`.
 
 ```bash
-make latexpdf  # output :build/latex/SNAC.pdf
+make  # output :build/latex/SNAC.pdf
 ```
 
 


### PR DESCRIPTION
### Summary of Changes

I assume Sphinx's autogenerated Makefile doesn't set a default goal because they don't want to assume which output format you consider the *default*. But it is otherwise standard that calling `make` without arguments will build the project's most-normal target - which is usually 'all'.

Create a new phony target for 'all' and have it build the latexpdf. Make it the default goal.


### Justification

Makes the build instructions a little more consistent with what an average dev would expect.


### Testing

* Ran `make` and confirmed that the `all` and `latexpdf` targets are executed.