### PR TITLE
section_3_1.rst: remove typo in section 3.1.19 title

### DIFF
--- a/source/section_3_1.rst
+++ b/source/section_3_1.rst
@@ -912,10 +912,10 @@ selected data structures such as files, records, or fields.
 
 
 
-.. _3-1-19--withdrawn--incorporated-into-3-1-18--451:
+.. _3-1-19--withdrawn--incorporated-into-3-1-18-:
 
 ------------------------------------------------
-3.1.19. Withdrawn: Incorporated into 3.1.18. 451
+3.1.19. Withdrawn: Incorporated into 3.1.18.
 ------------------------------------------------
 
 .. raw:: latex


### PR DESCRIPTION
### Summary of Changes

remove typo


### Justification

It looks like a typo to me. I assume it is a relic of some past form of this document.
