### PR TITLE
Added optional section and non-runtime partition encryption steps

### DIFF
--- a/source/appendix_1.rst
+++ b/source/appendix_1.rst
@@ -432,3 +432,67 @@ Configure Remote Logging
         /etc/init.d/syslog restart
 
     For more information on configuring syslog-ng, refer to the `Syslog-ng Github <https://github.com/syslog-ng/syslog-ng>`_.
+
+
+
+.. _optional-snac-configuration-instructions:
+
+----------------------------------------
+Optional SNAC Configuration Instructions
+----------------------------------------
+
+The following instructions outline additional configuration steps that may be performed at the discretion of the system maintainers. 
+These steps are not mandatory but can enhance the functionality or performance of the NILRT system. 
+System maintainers should evaluate their specific needs and decide whether to implement these configurations.
+
+.. _non-runtime-partition-encryption:
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Non-Runtime Partition Encryption
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+System maintainers should consider encrypting partitions on designs that store controlled data on 
+removable devices or non-runtime partitions to protect sensitive information.
+
+#.  Install the `cryptsetup` tool using `opkg`.
+
+    .. code-block:: bash
+
+        opkg install cryptsetup
+
+#.  Create a non-runtime partition (if needed) using the following commmands:
+
+    .. code-block:: bash
+
+        dd if=/dev/zero of=/tmp/test_partition bs=1M count=32
+        mkdir /mnt/test_partition
+    Note: Replace `/tmp/test_partition` with the desired file path and size for your partition.
+
+#.  Encrypt the partition.
+
+    .. code-block:: bash
+
+        cryptsetup luksFormat /tmp/test_partition
+    Note: You will be prompted to enter a secure passphrase.
+
+#.  Open the encrypted partition.
+
+    .. code-block:: bash
+    
+        cryptsetup luksOpen /tmp/test_partition test_partition
+
+#.  Format the encrypted partition.
+
+    .. code-block:: bash
+    
+        mkfs.ext4 /dev/mapper/test_partition_crypt
+
+#.  Mount the encrypted partition.
+
+    .. code-block:: bash
+
+        mount /dev/mapper/test_partition_crypt /mnt/test_partition
+
+After mounting the encrypted partition, you can use it just like any other filesystem.
+For additional encryption options or configurations using `cryptsetup`, refer to the `Cryptsetup Documentation <https://www.man7.org/linux/man-pages/man8/cryptsetup.8.html>`_.
+Please be aware that root partition encryption is not supported.

--- a/source/section_3_13.rst
+++ b/source/section_3_13.rst
@@ -260,15 +260,20 @@ information.
 |   | Not applicable                  |
 +---+---------------------------------+
 
-+----------------------------------------------------------------------------------+
-| Solution Implementation                                                          |
-+==================================================================================+
-| CUI in transit can be secured in LabVIEW over the TLS, SFTP, SSH, and            |
-| WebDAV+HTTPS protocols without additional software installation. CUI in storage  |
-| can be manually encrypted/decrypted by running command-line utilities through    |
-| System Exec, e.g. openssl, gnupg, etc. The use of VPNs allows unsecured          |
-| protocols to be used in a secure manner.                                         |
-+----------------------------------------------------------------------------------+
++-------------------------------------------------------------------------------------------------+
+| Solution Implementation                                                                         |
++=================================================================================================+
+| CUI in transit can be secured in LabVIEW over the TLS, SFTP, SSH, and WebDAV+HTTPS protocols    |
+| without additional software installation. Non-LabVIEW applications should use TLS or DTLS.      |
++-------------------------------------------------------------------------------------------------+
++-------------------------------------------------------------------------------------------------+
+| CUI in storage should either be stored in encrypted forms and only decrypted into memory using  |
+| the included `gnupg` and `openssl` utilties, or stored in a block-encrypted partition or        | 
+| removable storage device. For more information about how to setup an encrypted data             |
+| partition, see the                                                                              |
+| `Non-Runtime Partition Encryption <appendix_1.rst#non-runtime-partition-encryption>`_ section   |
+| in Appendix 1.                                                                                  |
++-------------------------------------------------------------------------------------------------+
 
 .. raw:: latex
 


### PR DESCRIPTION
### Summary of Changes

- Added optional SNAC configuration section
- Added steps on the recommended approach to encrypt non-runtime partitions


### Justification

There have been scenarios where additional configuration steps can enhance the functionality or performance of the system, although they are not mandatory. Providing a new section for these optional configurations ensures that system maintainers have access to valuable information that can optimize their setup based on specific needs. Non-runtime partition encryption falls into this category: [work item link](https://dev.azure.com/ni/DevCentral/_boards/board/t/PRnD%20Security/Work%20Items?System.AssignedTo=eli.engelhardt%40emerson.com&workitem=3061100)


### Testing

Testing for the steps on encryption of non-runtime partitions completed successfully for [build](https://dashboard.ni.systems/dashboard/#/mobilize?run_id=12211799&plan=6d9a67cf0c0911f096b6cf86557cc7a0 ) with the test named `test___non_runtime_partition_encryption`.