### PR TITLE
appendix_1.rst: change remote logging instructions to use UDP

### DIFF
--- a/source/appendix_1.rst
+++ b/source/appendix_1.rst
@@ -385,7 +385,7 @@ Configure Remote Logging
         ########################
         # Sources
         ########################
-        source s_net { tcp(ip(0.0.0.0) port(514)); udp(); };
+        source s_net { tcp(); udp(ip(0.0.0.0) port(514)); };
 
         ########################
         # Destinations
@@ -415,7 +415,7 @@ Configure Remote Logging
         };
 
         destination d_remote {
-            syslog("<Remote IP Address>" transport("tcp") port(514));
+            syslog("<Remote IP Address>" transport("udp") port(514));
         };
 
         log {


### PR DESCRIPTION
### Summary of Changes

change our example to use UDP instead of TCP


### Justification

The version of firewalld we use expects this traffic to be UDP [[reference][1]]. Our acceptance test uses UDP.

[AB#2870419](https://dev.azure.com/ni/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/2870419)

[1]: https://github.com/firewalld/firewalld/blob/88cc31b6210420a34f71938a7dc5d4b0d18a98ca/config/services/syslog.xml#L5
