### PR TITLE
appendix_2.rst: Fix windows firewall script and replace IPv6 with IPv4 in table

### DIFF
--- a/source/appendix_2.rst
+++ b/source/appendix_2.rst
@@ -142,7 +142,8 @@ Windows host instructions
         netsh advfirewall `
             firewall add rule `
                 name=nilrt-wireguard `
-                dir=inaction=allow `
+                dir=in `
+                action=allow `
                 protocol=ANY `
                 localip=${device_wg_address}/24 `
                 profile=any

--- a/source/appendix_2.rst
+++ b/source/appendix_2.rst
@@ -49,11 +49,11 @@ pseudocode variables, which you should replace before entry.
 |                           | target on local      |                               |               |
 |                           | network              |                               |               |
 +---------------------------+----------------------+-------------------------------+---------------+
-| ``${windows_wg_address}`` | IPv6 address of      | Choose from IPv4 private      | 192.168.94.1  |
+| ``${windows_wg_address}`` | IPv4 address of      | Choose from IPv4 private      | 192.168.94.1  |
 |                           | Windows host on      | network ranges, avoiding      |               |
 |                           | VPN                  | networks in use               |               |
 +---------------------------+----------------------+-------------------------------+---------------+
-| ``${device_wg_address}``  | IPv6 address of RT   | Same                          | 192.168.94.2  |
+| ``${device_wg_address}``  | IPv4 address of RT   | Same                          | 192.168.94.2  |
 |                           | target on            |                               |               |
 |                           | VPN                  |                               |               |
 +---------------------------+----------------------+-------------------------------+---------------+


### PR DESCRIPTION
### Summary of Changes

Fix windows firewall script and replace "IPv6" with "IPv4" in table to avoid confusion.

### Justification

The Windows firewall script was missing whitespace, causing it to fail when copy/pasted into powershell. Also, a couple of address variables in the table at the top are described as IPv6 but they are actually IPv4.
