### PR TITLE
Fixup 3.13.8 link and fix warnings.

### DIFF
--- a/source/appendix_1.rst
+++ b/source/appendix_1.rst
@@ -466,6 +466,7 @@ removable devices or non-runtime partitions to protect sensitive information.
 
         dd if=/dev/zero of=/tmp/test_partition bs=1M count=32
         mkdir /mnt/test_partition
+
     Note: Replace `/tmp/test_partition` with the desired file path and size for your partition.
 
 #.  Encrypt the partition.
@@ -473,6 +474,7 @@ removable devices or non-runtime partitions to protect sensitive information.
     .. code-block:: bash
 
         cryptsetup luksFormat /tmp/test_partition
+
     Note: You will be prompted to enter a secure passphrase.
 
 #.  Open the encrypted partition.

--- a/source/appendix_3.rst
+++ b/source/appendix_3.rst
@@ -6,7 +6,7 @@ Appendix 3: Firewall Configuration
 ==================================
 
 
-.. _introduction:
+.. _appendix-3--introduction:
 
 ------------
 Introduction

--- a/source/document_metadata.rst
+++ b/source/document_metadata.rst
@@ -4,6 +4,7 @@
     This header is necessary to keep latex from messing up the next document's headers.
     But it is nonprinting and does not generate a PDF bookmark.
     No idea why either of those is true.
+
 =================
 Document Metadata
 =================

--- a/source/section_3_13.rst
+++ b/source/section_3_13.rst
@@ -268,10 +268,10 @@ information.
 +-------------------------------------------------------------------------------------------------+
 +-------------------------------------------------------------------------------------------------+
 | CUI in storage should either be stored in encrypted forms and only decrypted into memory using  |
-| the included `gnupg` and `openssl` utilties, or stored in a block-encrypted partition or        | 
+| the included ``gnupg`` and ``openssl`` utilities, or stored in a block-encrypted partition or   | 
 | removable storage device. For more information about how to setup an encrypted data             |
 | partition, see the                                                                              |
-| `Non-Runtime Partition Encryption <appendix_1.rst#non-runtime-partition-encryption>`_ section   |
+| :ref:`Non-Runtime Partition Encryption<non-runtime-partition-encryption>` section               |
 | in Appendix 1.                                                                                  |
 +-------------------------------------------------------------------------------------------------+
 


### PR DESCRIPTION
### Summary of Changes

* Fixup the internal section link in control 3.13.8.
    * Fixes #28 
* Fix latex warnings throughout documents.

### Justification

#28


### Testing

* [x] Built the guide with these changes and verified that the 3.13.8 link how correctly links to the appendix section.
* [x] Verified that build warnings are now gone.


### Procedure

