### PR TITLE
consistently use "an" before "NILRT"

### DIFF
--- a/source/introduction.rst
+++ b/source/introduction.rst
@@ -32,7 +32,7 @@ The remainder of this document is organized as follows.
 
 * **Chapter 2** provides a general overview of NI Linux RT and the cRIO and PXIe platforms.
 * **Chapters 3 - 20** provide an enumeration of the total controls defined by NIST SP 800-171r3, and a summary of how the SNAC configuration satisfies the control, or what should be satisfied by implementing organizations.
-* **Appendix 1** provides a detailed description of the SNAC design, discusses application considerations, and provides instructions on how to deploy an NILRT cRIO/PXIe system into the SNAC configuration.
+* **Appendix 1** provides a detailed description of the SNAC design, discusses application considerations, and provides instructions on how to deploy a NILRT cRIO/PXIe system into the SNAC configuration.
 * **Appendix 2** provides detailed instructions on how to configure a Windows LabVIEW host to connect to a SNAC-configured NILRT device using the Wireguard VPN utility.
 * **Appendix 3** provides an administrative guide to configuring the NILRT firewall daemon to suit your application.
 * **Appendix 4** summarizes LabVIEW Real-Time feature support status in the SNAC configuration.

--- a/source/section_3_5.rst
+++ b/source/section_3_5.rst
@@ -97,7 +97,7 @@ networks.
 +==================================================================================+
 | NILRT supports 802.1X authentication on the network. Refer to the nilrt-docs     |
 | `documentation <https://nilrt-docs.ni.com/eapol/eapol.html>`__ at                |
-| *nilrt-docs.ni.com* for tutorials on how to configure an NILRT device to         |
+| *nilrt-docs.ni.com* for tutorials on how to configure a NILRT device to          |
 | authenticate to an 802.1X-enabled network. The system owner can use this         |
 | solution to identify and authenticate NILRT devices before establishing          |
 | a network connection.                                                            |


### PR DESCRIPTION
### Summary of Changes

consistently use "an" before "NILRT"


### Justification

Prior to this change, sometimes "a" is used and sometimes "an" is used.
