### PR TITLE
Add USBGuard documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 # Makefile (build) artifacts.
 /build
+/source/nilrt-docs

--- a/Makefile
+++ b/Makefile
@@ -2,8 +2,9 @@
 .DEFAULT_GOAL := all
 
 # Directories
-builddir  = build
-srcdir    = source
+builddir         = build
+srcdir           = source
+downloadedsrcdir = $(srcdir)/nilrt-docs
 
 # Binaries
 PYTHON ?= python3
@@ -11,13 +12,18 @@ PYTHON ?= python3
 SPHINXOPTS    ?=
 SPHINXBUILD   ?= $(PYTHON) -m sphinx
 
+NILRT_DOC_REPO = https://github.com/ni/nilrt-docs
+NILRT_DOC_BRANCH_OR_COMMIT ?= 4daf8c90d493a4be340b9ac6e03bb6a1a5e757b0
+
+USBGUARD_DOC_PATH = docs/source/usbguard/usbguard.rst
+USBGUARD_DOC_DEST = $(downloadedsrcdir)/usbguard.rst
 
 # REAL TARGETS #
 ################
 
 # Catch-all target: route all unknown targets to Sphinx using the new
 # "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
-% : Makefile fetch-usbguard-doc
+% : Makefile $(USBGUARD_DOC_DEST)
 	$(SPHINXBUILD) -M $@ "$(srcdir)" "$(builddir)" $(SPHINXOPTS) $(O)
 
 
@@ -29,19 +35,14 @@ SPHINXBUILD   ?= $(PYTHON) -m sphinx
 all : latexpdf
 .PHONY : all
 
-USBGUARD_DOC_REPO = https://github.com/ni/nilrt-docs
-USBGUARD_DOC_PATH = docs/source/usbguard/usbguard.rst
-USBGUARD_DOC_BRANCH_OR_COMMIT ?= 4daf8c90d493a4be340b9ac6e03bb6a1a5e757b0
-USBGUARD_DOC_DEST = $(builddir)/nilrt-docs/usbguard.rst
-
-.PHONY : fetch-usbguard-doc
-fetch-usbguard-doc :
-	@mkdir -p $(builddir)/nilrt-docs
-	curl -sSL "$(USBGUARD_DOC_REPO)/raw/$(USBGUARD_DOC_BRANCH_OR_COMMIT)/$(USBGUARD_DOC_PATH)" -o $(USBGUARD_DOC_DEST)
-	@echo "Downloaded usbguard.rst from branch '$(USBGUARD_DOC_BRANCH_OR_COMMIT)' to $(USBGUARD_DOC_DEST)"
+$(USBGUARD_DOC_DEST) :
+	@mkdir -p $(downloadedsrcdir)
+	curl -sSL "$(NILRT_DOC_REPO)/raw/$(NILRT_DOC_BRANCH_OR_COMMIT)/$(USBGUARD_DOC_PATH)" -o $(USBGUARD_DOC_DEST)
+	@echo "Downloaded usbguard.rst from branch '$(NILRT_DOC_BRANCH_OR_COMMIT)' to $(USBGUARD_DOC_DEST)"
 
 clean :
 	@rm -Rf $(builddir)
+	@rm -Rf $(downloadedsrcdir)
 .PHONY : clean
 
 

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ SPHINXBUILD   ?= $(PYTHON) -m sphinx
 
 # Catch-all target: route all unknown targets to Sphinx using the new
 # "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
-% : Makefile
+% : Makefile fetch-usbguard-doc
 	$(SPHINXBUILD) -M $@ "$(srcdir)" "$(builddir)" $(SPHINXOPTS) $(O)
 
 
@@ -29,6 +29,16 @@ SPHINXBUILD   ?= $(PYTHON) -m sphinx
 all : latexpdf
 .PHONY : all
 
+USBGUARD_DOC_REPO = https://github.com/ni/nilrt-docs
+USBGUARD_DOC_PATH = docs/source/usbguard/usbguard.rst
+USBGUARD_DOC_BRANCH_OR_COMMIT ?= 4daf8c90d493a4be340b9ac6e03bb6a1a5e757b0
+USBGUARD_DOC_DEST = $(builddir)/nilrt-docs/usbguard.rst
+
+.PHONY : fetch-usbguard-doc
+fetch-usbguard-doc :
+	@mkdir -p $(builddir)/nilrt-docs
+	curl -sSL "$(USBGUARD_DOC_REPO)/raw/$(USBGUARD_DOC_BRANCH_OR_COMMIT)/$(USBGUARD_DOC_PATH)" -o $(USBGUARD_DOC_DEST)
+	@echo "Downloaded usbguard.rst from branch '$(USBGUARD_DOC_BRANCH_OR_COMMIT)' to $(USBGUARD_DOC_DEST)"
 
 clean :
 	@rm -Rf $(builddir)

--- a/source/appendix_5.rst
+++ b/source/appendix_5.rst
@@ -1,0 +1,7 @@
+
+.. _appendix-5:
+
+Appendix 5: USBGuard Installation and Configuration
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. include:: ./nilrt-docs/usbguard.rst

--- a/source/index.rst
+++ b/source/index.rst
@@ -29,3 +29,4 @@
     appendix_2
     appendix_3
     appendix_4
+    appendix_5

--- a/source/introduction.rst
+++ b/source/introduction.rst
@@ -36,3 +36,4 @@ The remainder of this document is organized as follows.
 * **Appendix 2** provides detailed instructions on how to configure a Windows LabVIEW host to connect to a SNAC-configured NILRT device using the Wireguard VPN utility.
 * **Appendix 3** provides an administrative guide to configuring the NILRT firewall daemon to suit your application.
 * **Appendix 4** summarizes LabVIEW Real-Time feature support status in the SNAC configuration.
+* **Appendix 5** provides instructions for USBGuard installation and configuration in the SNAC configuration.

--- a/source/section_3_8.rst
+++ b/source/section_3_8.rst
@@ -308,16 +308,18 @@ malicious code).
 +---+---------------------------------+
 |   | Not implemented by vendor       |
 +---+---------------------------------+
-|   | Must be implemented by end user |
+| X | Must be implemented by end user |
 +---+---------------------------------+
-| X | Not applicable                  |
+|   | Not applicable                  |
 +---+---------------------------------+
 
 +----------------------------------------------------------------------------------+
 | Solution Implementation                                                          |
 +==================================================================================+
-| It is the responsibility of the system owner to create a plan for managing media |
-| used with the system.                                                            |
+| To restrict or prohibit the use of removable media, system owners should develop |
+| a media management plan and consider technical controls such as USBGuard.        |
+| For details on configuring USBGuard, see                                         |
+| :ref:`Appendix 5 <appendix-5>`                                                   |
 +----------------------------------------------------------------------------------+
 
 .. raw:: latex


### PR DESCRIPTION
### Summary of Changes

* Update section 3.8.7 regarding "Media Use" to show it is now "implemented by user"
* Add link in section 3.8.7 to Appendix 5: USBGuard Installation and Configuration
* Add Appendix 5 for USBGuard, use usbguard content from nilrt-docs

### Justification

[AB#3094299](https://dev.azure.com/ni/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/3094299)

### Testing

Built locally and checked resulting PDF
