### PR TITLE
Add note for variables hosted on My Computer

### DIFF
--- a/source/appendix_4.rst
+++ b/source/appendix_4.rst
@@ -57,13 +57,8 @@ configuration and a working WireGuard connection.
 +----------------------+-------------------+---------------------------+
 | HWCU (general use)   | Supported         |                           |
 +----------------------+-------------------+---------------------------+
-| Network Shared       | Supported         | For variables hosted on   |
-| Variables            |                   | the desktop, enable       |
-|                      |                   | 'Specify custom address'  |
-|                      |                   | and enter the WireGuard   |
-|                      |                   | address on the General    |
-|                      |                   | page of the My Computer   |
-|                      |                   | Properties dialog.        |
+| Network Shared       | Supported         | See note below.           |
+| Variables            |                   |                           |
 +----------------------+-------------------+---------------------------+
 | Network Streams      | Supported         |                           |
 +----------------------+-------------------+---------------------------+
@@ -93,3 +88,13 @@ configuration and a working WireGuard connection.
 .. raw:: latex
 
     \scalefont{1.25}
+
+.. _hosting-shared-variables-on-my-computer:
+
+---------------------------------------
+Hosting Shared Variables on My Computer
+---------------------------------------
+
+To access shared variables hosted on My Computer from your RT target,
+update the My Computer alias to point to the WireGuard address. To do
+this, specify a custom address on the My Computer item's `General page <https://www.ni.com/docs/en-US/bundle/labview-api-ref/page/resource/framework/providers/lvdesktop-llb/prefpage-mycomputer.html>`__.

--- a/source/appendix_4.rst
+++ b/source/appendix_4.rst
@@ -57,8 +57,9 @@ configuration and a working WireGuard connection.
 +----------------------+-------------------+---------------------------+
 | HWCU (general use)   | Supported         |                           |
 +----------------------+-------------------+---------------------------+
-| Network Shared       | Supported         | See note below.           |
-| Variables            |                   |                           |
+| Network Shared       | Supported         | See the *Hosting Network* |
+| Variables            |                   | *Shared Variables*        |
+|                      |                   | section below.            |
 +----------------------+-------------------+---------------------------+
 | Network Streams      | Supported         |                           |
 +----------------------+-------------------+---------------------------+
@@ -89,11 +90,11 @@ configuration and a working WireGuard connection.
 
     \scalefont{1.25}
 
-.. _hosting-shared-variables-on-my-computer:
+.. _hosting-network-shared-variables:
 
----------------------------------------
-Hosting Shared Variables on My Computer
----------------------------------------
+--------------------------------
+Hosting Network Shared Variables
+--------------------------------
 
 To access shared variables hosted on My Computer from your RT target,
 update the My Computer alias to point to the WireGuard address. To do

--- a/source/appendix_4.rst
+++ b/source/appendix_4.rst
@@ -57,8 +57,13 @@ configuration and a working WireGuard connection.
 +----------------------+-------------------+---------------------------+
 | HWCU (general use)   | Supported         |                           |
 +----------------------+-------------------+---------------------------+
-| Network Shared       | Supported         |                           |
-| Variables            |                   |                           |
+| Network Shared       | Supported         | For variables hosted on   |
+| Variables            |                   | the desktop, enable       |
+|                      |                   | 'Specify custom address'  |
+|                      |                   | and enter the WireGuard   |
+|                      |                   | address on the General    |
+|                      |                   | page of the My Computer   |
+|                      |                   | Properties dialog.        |
 +----------------------+-------------------+---------------------------+
 | Network Streams      | Supported         |                           |
 +----------------------+-------------------+---------------------------+


### PR DESCRIPTION
### Summary of Changes

Add note about how to change the My Computer alias so that variables hosted on My Computer are accessible via snac-enabled target.


### Justification

The url of a My Computer-hosted shared variable defaults to using the "primary" IP address. This can be seen by going to the General property page of the My Computer item. To work with a SNAC-enabled target, we need to update that to the Wireguard IP. See [bug 3122615](https://dev.azure.com/ni/DevCentral/_workitems/edit/3122615/) for more details.


### Testing

N/A


### Procedure

